### PR TITLE
fix: switch to tag-only releases to avoid branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ jobs:
       - name: Install semantic-release plugins
         run: |
           npm install --save-dev \
-            @semantic-release/changelog \
-            @semantic-release/git \
             @semantic-release/github \
             @semantic-release/npm \
             @semantic-release/commit-analyzer \
@@ -63,12 +61,7 @@ jobs:
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
-        run: |
-          # Note: This requires either:
-          # 1. A PAT with bypass branch protection permissions (secrets.RELEASE_TOKEN)
-          # 2. Or temporarily disable "Include administrators" in branch protection
-          # 3. Or add github-actions[bot] to bypass list in branch protection
-          npx semantic-release
+        run: npx semantic-release
 
       # Sign artifacts if release was created
       - name: Install cosign

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
     [
       "@semantic-release/npm",
       {
@@ -11,12 +10,13 @@
       }
     ],
     [
-      "@semantic-release/git",
+      "@semantic-release/github",
       {
-        "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "assets": [
+          {"path": "qrtak-dist.tgz", "label": "Distribution archive"},
+          {"path": "qrtak-dist.tgz.sig", "label": "Distribution signature"}
+        ]
       }
-    ],
-    "@semantic-release/github"
+    ]
   ]
 }


### PR DESCRIPTION
## Summary
- Removes file commits from semantic-release to avoid branch protection conflicts
- Maintains security by keeping branch protection rules intact
- Version tracking now via git tags only

## Changes
- Removed @semantic-release/git and @semantic-release/changelog plugins
- Semantic-release now only creates tags and GitHub releases
- No commits pushed back to main (no package.json or CHANGELOG.md updates)

## Benefits
- ✅ No need for PAT with bypass permissions
- ✅ Full branch protection remains active
- ✅ Cleaner git history (no 'chore(release)' commits)
- ✅ GitHub releases still created with assets

## Trade-offs
- Version in package.json won't auto-update (stays at 0.0.0-development)
- No CHANGELOG.md file (but GitHub releases have full notes)

Closes #27