### PR TITLE
fix: add release detection for Docker trigger

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -150,13 +150,13 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.event.release.tag_name }}
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ inputs.version }}
           format: spdx-json
           output-file: sbom.spdx.json
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:
-          name: sbom-${{ github.event.release.tag_name }}
+          name: sbom-v${{ inputs.version }}
           path: sbom.spdx.json
           retention-days: 90

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -121,11 +121,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,priority=1000
-            type=raw,value=${{ github.event.release.tag_name }}
-            type=raw,value=${{ github.event.release.tag_name }},suffix=,enable=${{ !startsWith(github.event.release.tag_name, 'v') }}
-            type=semver,pattern={{version}},value=${{ github.event.release.tag_name }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ github.event.release.tag_name }}
-            type=semver,pattern={{major}},value=${{ github.event.release.tag_name }}
+            type=raw,value=v${{ inputs.version }}
+            type=semver,pattern={{version}},value=v${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ inputs.version }}
+            type=semver,pattern={{major}},value=v${{ inputs.version }}
           labels: |
             org.opencontainers.image.title=qrtak
             org.opencontainers.image.description=Generate TAK client configuration QR codes instantly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     outputs:
-      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
-      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_published: ${{ steps.check_release.outputs.new_release_published }}
+      new_release_version: ${{ steps.check_release.outputs.new_release_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -62,22 +62,39 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: npx semantic-release
-
-      # Sign artifacts if release was created
-      - name: Install cosign
-        if: steps.semantic.outputs.new_release_published == 'true'
-        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
-
-      - name: Sign artifact
-        if: steps.semantic.outputs.new_release_published == 'true'
-        run: cosign sign-blob --yes --output-signature qrtak-dist.tgz.sig qrtak-dist.tgz
-
-      - name: Upload release assets
-        if: steps.semantic.outputs.new_release_published == 'true'
+      
+      - name: Check if release was created
+        id: check_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload v${{ steps.semantic.outputs.new_release_version }} \
+          # Get the latest release
+          LATEST_TAG=$(gh release list --limit 1 --json tagName -q '.[0].tagName')
+          LATEST_COMMIT=$(git rev-parse HEAD)
+          
+          # Check if this commit has the latest tag
+          if [ -n "$LATEST_TAG" ] && git tag --points-at HEAD | grep -q "^${LATEST_TAG}$"; then
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
+            echo "new_release_version=${LATEST_TAG#v}" >> $GITHUB_OUTPUT
+          else
+            echo "new_release_published=false" >> $GITHUB_OUTPUT
+          fi
+
+      # Sign artifacts if release was created
+      - name: Install cosign
+        if: steps.check_release.outputs.new_release_published == 'true'
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
+
+      - name: Sign artifact
+        if: steps.check_release.outputs.new_release_published == 'true'
+        run: cosign sign-blob --yes --output-signature qrtak-dist.tgz.sig qrtak-dist.tgz
+
+      - name: Upload release assets
+        if: steps.check_release.outputs.new_release_published == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload v${{ steps.check_release.outputs.new_release_version }} \
             qrtak-dist.tgz \
             qrtak-dist.tgz.sig \
             --clobber


### PR DESCRIPTION
## Summary
Fixes the automatic Docker image building that wasn't triggering after releases.

## Problem
When PR #28 was merged and v2.0.0 was created, the Docker workflow wasn't automatically triggered because semantic-release doesn't set GitHub Actions outputs by default.

## Solution
Added explicit release detection step that:
1. Checks if the current commit has a release tag
2. Sets the appropriate outputs for downstream jobs
3. Ensures Docker images are built automatically after releases

## Test Plan
- [x] Manual Docker build for v2.0.0 triggered successfully
- [ ] Next release will automatically trigger Docker builds