### PR TITLE
Fix renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,6 +13,7 @@ jobs:
   renovate:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@063e0c946b9c1af35ef3450efc44114925d6e8e6 # v40.1.11
         with:


### PR DESCRIPTION
## Summary
- checkout repo before running the Renovate GitHub Action

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e6143eb88832cbef99df76e2e4bb6