### PR TITLE
Add utils module with tests

### DIFF
--- a/src/js/__tests__/utils.test.js
+++ b/src/js/__tests__/utils.test.js
@@ -1,0 +1,75 @@
+import {
+  sanitizeInput,
+  extractHostnameFromURL,
+  isValidHostname,
+  isValidPort,
+  isValidURL,
+  debounce
+} from '../utils.js';
+
+describe('sanitizeInput', () => {
+  it('escapes HTML characters', () => {
+    document.body.innerHTML = '<div></div>';
+    const result = sanitizeInput('<script>');
+    expect(result).toBe('&lt;script&gt;');
+  });
+});
+
+describe('extractHostnameFromURL', () => {
+  it('handles full URLs', () => {
+    expect(extractHostnameFromURL('https://example.com/path')).toBe('example.com');
+  });
+
+  it('handles URLs without protocol', () => {
+    expect(extractHostnameFromURL('example.com')).toBe('example.com');
+  });
+
+  it('returns empty string for invalid input', () => {
+    expect(extractHostnameFromURL(null)).toBe('');
+  });
+});
+
+describe('isValidHostname', () => {
+  it('validates hostnames and IPs', () => {
+    expect(isValidHostname('example.com')).toBe(true);
+    expect(isValidHostname('192.168.1.1')).toBe(true);
+  });
+
+  it('rejects invalid hostnames', () => {
+    expect(isValidHostname('bad_host!')).toBe(false);
+  });
+});
+
+describe('isValidPort', () => {
+  it('validates ports', () => {
+    expect(isValidPort('80')).toBe(true);
+    expect(isValidPort(65535)).toBe(true);
+  });
+
+  it('rejects invalid ports', () => {
+    expect(isValidPort('70000')).toBe(false);
+  });
+});
+
+describe('isValidURL', () => {
+  it('validates URLs', () => {
+    expect(isValidURL('https://example.com')).toBe(true);
+  });
+
+  it('rejects invalid URLs', () => {
+    expect(isValidURL('http://')).toBe(false);
+  });
+});
+
+describe('debounce', () => {
+  jest.useFakeTimers();
+
+  it('delays function execution', () => {
+    const fn = jest.fn();
+    const debounced = debounce(fn, 200);
+    debounced();
+    expect(fn).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(200);
+    expect(fn).toHaveBeenCalled();
+  });
+});

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,12 @@
 import QRCode from 'qrcode';
+import {
+  debounce,
+  sanitizeInput,
+  extractHostnameFromURL,
+  isValidHostname,
+  isValidPort,
+  isValidURL
+} from './utils.js';
 
 // ============================================================================
 // Constants and Configuration
@@ -54,106 +62,6 @@ const ERROR_MESSAGES = {
   LOAD_PROFILES_ERROR: 'Error loading profiles'
 };
 
-// ============================================================================
-// Utility Functions
-// ============================================================================
-
-/**
- * Debounce function to limit rate of function calls
- * @param {Function} func - Function to debounce
- * @param {number} wait - Delay in milliseconds
- * @returns {Function} Debounced function
- */
-function debounce (func, wait) {
-  let timeout;
-  return function executedFunction (...args) {
-    const later = () => {
-      clearTimeout(timeout);
-      func.apply(this, args);
-    };
-    clearTimeout(timeout);
-    timeout = setTimeout(later, wait);
-  };
-}
-
-/**
- * Sanitize user input to prevent XSS
- * @param {string} input - User input to sanitize
- * @returns {string} Sanitized input
- */
-function sanitizeInput (input) {
-  const div = document.createElement('div');
-  div.textContent = input;
-  return div.innerHTML;
-}
-
-/**
- * Extract hostname from URL with robust error handling
- * @param {string} url - URL to parse
- * @returns {string} Extracted hostname or empty string
- */
-function extractHostnameFromURL (url) {
-  if (!url || typeof url !== 'string') {
-    return '';
-  }
-
-  try {
-    const trimmedUrl = url.trim();
-    const urlToParse = trimmedUrl.startsWith('http') ? trimmedUrl : `https://${trimmedUrl}`;
-    const urlObj = new URL(urlToParse);
-    return urlObj.hostname;
-  } catch {
-    // Fallback parsing for invalid URLs
-    const urlParts = url.trim().replace(/^https?:\/\//, '').split('/');
-    const [hostPart] = urlParts;
-    const [hostName] = hostPart.split(':');
-    return hostName || '';
-  }
-}
-
-/**
- * Validate hostname/IP address
- * @param {string} hostname - Hostname to validate
- * @returns {boolean} True if valid
- */
-function isValidHostname (hostname) {
-  if (!hostname) {
-    return false;
-  }
-  // Check for IP address
-  const ipPattern = /^(\d{1,3}\.){3}\d{1,3}$/;
-  if (ipPattern.test(hostname)) {
-    const parts = hostname.split('.');
-    return parts.every(part => parseInt(part) >= 0 && parseInt(part) <= 255);
-  }
-  // Check for hostname
-  return CONFIG.PATTERNS.HOSTNAME.test(hostname);
-}
-
-/**
- * Validate port number
- * @param {string|number} port - Port to validate
- * @returns {boolean} True if valid
- */
-function isValidPort (port) {
-  return CONFIG.PATTERNS.PORT.test(String(port));
-}
-
-/**
- * Validate URL
- * @param {string} url - URL to validate
- * @returns {boolean} True if valid
- */
-function isValidURL (url) {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-// ============================================================================
 // Tab Manager Module
 // ============================================================================
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,0 +1,66 @@
+export const PATTERNS = {
+  HOSTNAME: /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,60}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,60}[a-zA-Z0-9])?)*$/,
+  PORT: /^([1-9][0-9]{0,3}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$/,
+  URL: /^https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)$/
+};
+
+export function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func.apply(this, args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
+
+export function sanitizeInput(input) {
+  const div = document.createElement('div');
+  div.textContent = input;
+  return div.innerHTML;
+}
+
+export function extractHostnameFromURL(url) {
+  if (!url || typeof url !== 'string') {
+    return '';
+  }
+
+  try {
+    const trimmedUrl = url.trim();
+    const urlToParse = trimmedUrl.startsWith('http') ? trimmedUrl : `https://${trimmedUrl}`;
+    const urlObj = new URL(urlToParse);
+    return urlObj.hostname;
+  } catch {
+    const urlParts = url.trim().replace(/^https?:\/\//, '').split('/');
+    const [hostPart] = urlParts;
+    const [hostName] = hostPart.split(':');
+    return hostName || '';
+  }
+}
+
+export function isValidHostname(hostname) {
+  if (!hostname) {
+    return false;
+  }
+  const ipPattern = /^(\d{1,3}\.){3}\d{1,3}$/;
+  if (ipPattern.test(hostname)) {
+    const parts = hostname.split('.');
+    return parts.every(part => parseInt(part) >= 0 && parseInt(part) <= 255);
+  }
+  return PATTERNS.HOSTNAME.test(hostname);
+}
+
+export function isValidPort(port) {
+  return PATTERNS.PORT.test(String(port));
+}
+
+export function isValidURL(url) {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/fuzz.test.js
+++ b/tests/fuzz.test.js
@@ -78,4 +78,4 @@ function fuzzInputValidation(data) {
 module.exports = {
   fuzzQRGeneration,
   fuzzInputValidation
-};
+}


### PR DESCRIPTION
## Summary
- extract utility functions into a new `utils.js` module
- import utilities in `main.js`
- add `utils.test.js` to cover sanitization and validation helpers
- clean up stray characters in fuzz test

## Testing
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_687ca716c91c832cb0a96425545b7149