### PR TITLE
Add cross-fade for QR code updates

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -200,11 +200,30 @@ const QRGenerator = (function () {
         }
       });
 
-      container.innerHTML = '';
+      // Remove placeholder if present
+      const placeholder = container.querySelector('.qr-placeholder');
+      if (placeholder) {
+        placeholder.remove();
+      }
+
+      const oldCanvas = container.querySelector('canvas');
+
       container.setAttribute('aria-label', 'QR code generated successfully');
       if (canvas && typeof canvas === 'object' && canvas.nodeType === 1) {
+        canvas.style.opacity = '0';
         container.appendChild(canvas);
+
+        // Trigger fade-in
+        canvas.offsetHeight; // force reflow
+        canvas.style.opacity = '1';
+
+        // Fade out old canvas if it exists
+        if (oldCanvas) {
+          oldCanvas.style.opacity = '0';
+          oldCanvas.addEventListener('transitionend', () => oldCanvas.remove(), { once: true });
+        }
       }
+
       return canvas;
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -516,12 +516,20 @@ a:hover {
   background-color: var(--color-background);
   border-radius: var(--radius-md);
   margin-bottom: var(--spacing-lg);
+  position: relative;
+  overflow: hidden;
 }
 
 .qr-container canvas {
   max-width: 100%;
   height: auto;
   image-rendering: crisp-edges;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
 }
 
 .qr-placeholder {


### PR DESCRIPTION
## Summary
- apply relative positioning and opacity transition to QR container canvases
- fade out old QR code and fade in the new one when generating a code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68841dce765c832cab8e2a5d36f229a5