### PR TITLE
fix(ci): Fix auto-merge workflow field names

### DIFF
--- a/.github/workflows/auto-merge-universal.yml
+++ b/.github/workflows/auto-merge-universal.yml
@@ -93,11 +93,11 @@ jobs:
           PR_NUMBER="${{ steps.pr-details.outputs.pr-number }}"
 
           # Check if all required status checks have passed
-          PR_STATUS=$(gh pr checks $PR_NUMBER --repo ${{ github.repository }} --json name,status,conclusion)
+          PR_STATUS=$(gh pr checks $PR_NUMBER --repo ${{ github.repository }} --json name,state,bucket)
 
           # Check for any failing or pending required checks
-          FAILED_CHECKS=$(echo "$PR_STATUS" | jq '[.[] | select(.status == "COMPLETED" and .conclusion != "SUCCESS" and .conclusion != "SKIPPED")] | length')
-          PENDING_CHECKS=$(echo "$PR_STATUS" | jq '[.[] | select(.status != "COMPLETED")] | length')
+          FAILED_CHECKS=$(echo "$PR_STATUS" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
+          PENDING_CHECKS=$(echo "$PR_STATUS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED")] | length')
 
           if [[ "$FAILED_CHECKS" -gt 0 ]]; then
             echo "PR has failing checks"


### PR DESCRIPTION
Quick fix for auto-merge workflow - the gh pr checks command uses different field names than expected.

## Issue
Auto-merge workflow was failing because it was looking for `status` field but gh pr checks returns `state` field.

## Fix
- Changed from `status` to `state`  
- Updated values from COMPLETED/SUCCESS to PENDING/FAILURE/ERROR

This should allow dependabot PRs to auto-merge properly.