### PR TITLE
fix(ci): Ignore E2E test failures in auto-merge

### DIFF
--- a/.github/workflows/auto-merge-universal.yml
+++ b/.github/workflows/auto-merge-universal.yml
@@ -95,8 +95,8 @@ jobs:
           # Check if all required status checks have passed
           PR_STATUS=$(gh pr checks $PR_NUMBER --repo ${{ github.repository }} --json name,state,bucket)
 
-          # Check for any failing or pending required checks
-          FAILED_CHECKS=$(echo "$PR_STATUS" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
+          # Check for any failing or pending required checks (ignore E2E Tests which are non-blocking)
+          FAILED_CHECKS=$(echo "$PR_STATUS" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR") | select(.name != "E2E Tests")] | length')
           PENDING_CHECKS=$(echo "$PR_STATUS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED")] | length')
 
           if [[ "$FAILED_CHECKS" -gt 0 ]]; then


### PR DESCRIPTION
E2E tests are marked as non-blocking but were still preventing auto-merge.

This fix excludes E2E Tests from the failure check since they're already marked with `continue-on-error: true` in the CI workflow.