### PR TITLE
fix(ui): use username in QR code download filenames

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,6 +470,13 @@
                                                 <button id="bulk-next" class="btn btn-primary" data-testid="bulk-next">Next</button>
                                             </div>
 
+                                            <div class="qr-actions">
+                                                <button id="bulk-download" class="btn btn-primary" data-testid="bulk-download">
+                                                    <span class="btn-icon">⬇️</span>
+                                                    Download PNG
+                                                </button>
+                                            </div>
+
                                             <div class="form-grid">
                                                 <div class="form-group form-group-full">
                                                     <label>Enrollment URI</label>

--- a/src/js/__tests__/integration.test.js
+++ b/src/js/__tests__/integration.test.js
@@ -248,6 +248,80 @@ describe('TAK Config Integration Tests', () => {
       // Restore original createElement
       document.createElement.mockRestore();
     });
+
+    test('Download PNG should use username when available', async () => {
+      const hostInput = document.getElementById('tak-host');
+      const usernameInput = document.getElementById('tak-username');
+
+      // Set host and username
+      hostInput.value = 'tak.example.com';
+      usernameInput.value = 'testuser123';
+      hostInput.dispatchEvent(new Event('input'));
+
+      // Wait for QR to be generated
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      // Mock createElement to capture the download link
+      const originalCreateElement = document.createElement.bind(document);
+      let downloadLink = null;
+      jest.spyOn(document, 'createElement').mockImplementation((tagName) => {
+        const element = originalCreateElement(tagName);
+        if (tagName === 'a') {
+          downloadLink = element;
+          element.click = jest.fn();
+        }
+        return element;
+      });
+
+      // Call UIController.downloadQR directly
+      if (window.UIController && window.UIController.downloadQR) {
+        window.UIController.downloadQR('tak');
+      }
+
+      // Verify the download filename uses username
+      expect(downloadLink).not.toBeNull();
+      expect(downloadLink.download).toBe('testuser123.png');
+
+      // Restore original createElement
+      document.createElement.mockRestore();
+    });
+
+    test('Download PNG should fallback to generic name when username is empty', async () => {
+      const hostInput = document.getElementById('tak-host');
+      const usernameInput = document.getElementById('tak-username');
+
+      // Set host but leave username empty
+      hostInput.value = 'tak.example.com';
+      usernameInput.value = '';
+      hostInput.dispatchEvent(new Event('input'));
+
+      // Wait for QR to be generated
+      await new Promise(resolve => setTimeout(resolve, 300));
+
+      // Mock createElement to capture the download link
+      const originalCreateElement = document.createElement.bind(document);
+      let downloadLink = null;
+      jest.spyOn(document, 'createElement').mockImplementation((tagName) => {
+        const element = originalCreateElement(tagName);
+        if (tagName === 'a') {
+          downloadLink = element;
+          element.click = jest.fn();
+        }
+        return element;
+      });
+
+      // Call UIController.downloadQR directly
+      if (window.UIController && window.UIController.downloadQR) {
+        window.UIController.downloadQR('tak');
+      }
+
+      // Verify the download filename uses generic format
+      expect(downloadLink).not.toBeNull();
+      expect(downloadLink.download).toBe('tak-tak-config.png');
+
+      // Restore original createElement
+      document.createElement.mockRestore();
+    });
   });
 
   describe('QR Code Generation Edge Cases', () => {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -654,6 +654,32 @@ const BulkUsers = (function () {
         btn.textContent = hidden ? 'Hide Password' : 'Show Password';
       }
     });
+
+    // Download button handler for bulk onboard
+    const downloadBtn = document.getElementById('bulk-download');
+    downloadBtn?.addEventListener('click', async () => {
+      const user = users[currentIndex];
+      if (!user) {
+        return;
+      }
+
+      const container = document.getElementById('bulk-user-qr');
+      const canvas = container?.querySelector('canvas');
+      if (!canvas) {
+        return;
+      }
+
+      try {
+        const link = document.createElement('a');
+        link.download = `${user.username}.png`;
+        link.href = canvas.toDataURL();
+        link.click();
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(ERROR_MESSAGES.DOWNLOAD_ERROR, error);
+        UIController.showNotification(ERROR_MESSAGES.DOWNLOAD_ERROR, 'error');
+      }
+    });
   }
 
   function validateBulkHost () {
@@ -3098,8 +3124,18 @@ const UIController = (function () {
     }
 
     try {
+      let filename = `tak-${type}-config.png`;
+
+      // Use username if available for TAK config
+      if (type === 'tak') {
+        const username = document.getElementById('tak-username')?.value?.trim();
+        if (username) {
+          filename = `${username}.png`;
+        }
+      }
+
       const link = document.createElement('a');
-      link.download = `tak-${type}-config.png`;
+      link.download = filename;
       link.href = canvas.toDataURL();
       link.click();
     } catch (error) {


### PR DESCRIPTION
## Summary

- Updated QR code download filenames to use username instead of generic names
- Added download button to Bulk Onboard tab
- Filenames now use `{username}.png` format for better organization

## Changes

### TAK Config Tab
- Modified `downloadQR()` function to check for username field (src/js/main.js:3100-3109)
- When username is present, downloads as `{username}.png` instead of `tak-tak-config.png`
- Falls back to original generic naming when username is empty

### Bulk Onboard Tab  
- Added download button to bulk user interface (index.html:473-478)
- Added event handler for bulk download (src/js/main.js:658-682)
- Each user's QR code downloads with their username as filename

## Benefits

✅ **Better Organization** - Downloaded files are immediately identifiable by username  
✅ **Bulk Processing** - When onboarding multiple users, each QR code has a unique, meaningful filename  
✅ **Consistency** - Same filename pattern across TAK Config and Bulk Onboard tabs  
✅ **User Experience** - No manual renaming required after download

## Testing

- ✅ Lint passed
- ✅ Build successful
- ✅ Dev server running without errors

## Related Issue

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)