### PR TITLE
fix: correct manifest.xml filename casing in ATAK data packages

### DIFF
--- a/docs/data-packages.md
+++ b/docs/data-packages.md
@@ -19,7 +19,7 @@ TAK data packages are compressed files containing configuration files, certifica
 
 At minimum, a data package requires:
 - `config.pref` - Configuration preferences file
-- `MANIFEST.xml` - Package manifest defining contents and metadata
+- `manifest.xml` - Package manifest defining contents and metadata
 - Certificate files (`.p12` format)
 
 ### 2.2 Directory Organization
@@ -31,7 +31,7 @@ dataPackage/
 │   ├── caCert.p12
 │   └── clientCert.p12 (soft-cert only)
 └── MANIFEST/
-    └── MANIFEST.xml
+    └── manifest.xml
 ```
 
 ---
@@ -104,9 +104,9 @@ dataPackage/
 
 ---
 
-## 4. Manifest File (MANIFEST.xml)
+## 4. Manifest File (manifest.xml)
 
-### 4.1 Soft-Certificate MANIFEST.xml
+### 4.1 Soft-Certificate manifest.xml
 
 ```xml
 <MissionPackageManifest version="2">
@@ -123,7 +123,7 @@ dataPackage/
 </MissionPackageManifest>
 ```
 
-### 4.2 Certificate Auto-Enrollment MANIFEST.xml
+### 4.2 Certificate Auto-Enrollment manifest.xml
 
 ```xml
 <MissionPackageManifest version="2">
@@ -170,10 +170,10 @@ dataPackage/
 │   ├── DataSync-1.1.0.0-4.7.0.163
 │   └── TAKChat-1.0.0.0-4.7.0.163
 └── MANIFEST/
-    └── MANIFEST.xml
+    └── manifest.xml
 ```
 
-Updated MANIFEST.xml with additional content:
+Updated manifest.xml with additional content:
 
 ```xml
 <MissionPackageManifest version="2">
@@ -255,9 +255,9 @@ where `PROTOCOL` is `ssl` (HTTPS) or `tcp` (HTTP). QUIC is not supported in iTAK
 ### 7.1 Creating the Package
 
 1. **Organize Files**: Create the directory structure with all required files
-2. **Generate UUID**: Create a unique UID for the MANIFEST.xml
+2. **Generate UUID**: Create a unique UID for the manifest.xml
 3. **Compress**: Select all folders/files and create a ZIP archive
-4. **Rename**: Name the compressed file to match the `name` parameter in MANIFEST.xml
+4. **Rename**: Name the compressed file to match the `name` parameter in manifest.xml
 
 ### 7.2 Deployment Methods
 
@@ -296,7 +296,7 @@ where `PROTOCOL` is `ssl` (HTTPS) or `tcp` (HTTP). QUIC is not supported in iTAK
 
 | Issue | Cause | Solution |
 |-------|-------|----------|
-| Import fails | Incorrect file paths in MANIFEST.xml | Verify zipEntry paths match actual file structure |
+| Import fails | Incorrect file paths in manifest.xml | Verify zipEntry paths match actual file structure |
 | Certificate errors | Wrong certificate format or password | Ensure .p12 format and correct passwords |
 | Connection failures | Incorrect connectString format | Verify `HOST:PORT:PROTOCOL` format |
 
@@ -304,9 +304,9 @@ where `PROTOCOL` is `ssl` (HTTPS) or `tcp` (HTTP). QUIC is not supported in iTAK
 
 - [ ] Unique UID generated and used
 - [ ] All required files included in package
-- [ ] File paths in MANIFEST.xml match actual structure
+- [ ] File paths in manifest.xml match actual structure
 - [ ] Certificate passwords correctly specified
-- [ ] Package name matches MANIFEST.xml name parameter
+- [ ] Package name matches manifest.xml name parameter
 - [ ] Package tested with target TAK client version
 
 ---

--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
                     <div class="tab-pane" id="packages-tab" role="tabpanel" aria-labelledby="packages-btn">
                         <div class="form-section">
                             <h2>Data Package Builder</h2>
-                            <p class="form-description">Create ATAK/WinTAK/iTAK data packages with config.pref, MANIFEST.xml, and optional files</p>
+                            <p class="form-description">Create ATAK/WinTAK/iTAK data packages with config.pref, manifest.xml, and optional files</p>
 
                             <form id="package-form" class="config-form">
                                 <div class="form-group">
@@ -654,7 +654,7 @@
                                     </div>
                                     <div class="help-tab-item">
                                         <h4>URL Import</h4>
-                                        <p>Build ATAK/WinTAK/iTAK packages with <code>config.pref</code> and <code>MANIFEST.xml</code>. When <strong>client = iTAK</strong>, protocol tokens are <code>ssl</code> (HTTPS) and <code>tcp</code> (HTTP); QUIC is hidden.</p>
+                                        <p>Build ATAK/WinTAK/iTAK packages with <code>config.pref</code> and <code>manifest.xml</code>. When <strong>client = iTAK</strong>, protocol tokens are <code>ssl</code> (HTTPS) and <code>tcp</code> (HTTP); QUIC is hidden.</p>
                                         <div class="help-features">
                                             <span class="feature-tag">Packages</span>
                                             <span class="feature-tag">ATAK/WinTAK/iTAK</span>

--- a/src/js/__tests__/packageBuilder.test.js
+++ b/src/js/__tests__/packageBuilder.test.js
@@ -234,7 +234,7 @@ describe('PackageBuilder', () => {
       // Verify ZIP structure for ATAK (files in certs folder)
       expect(mockZipFolder).toHaveBeenCalledWith('certs');
       expect(mockZipFile).toHaveBeenCalledWith(
-        'MANIFEST.xml',
+        'manifest.xml',
         expect.stringContaining('<MissionPackageManifest')
       );
 
@@ -276,7 +276,7 @@ describe('PackageBuilder', () => {
 
       // Verify ZIP structure for iTAK (files in root, not in certs folder)
       expect(mockZipFile).toHaveBeenCalledWith(
-        'MANIFEST.xml',
+        'manifest.xml',
         expect.stringContaining('<MissionPackageManifest')
       );
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -2031,7 +2031,7 @@ const PackageBuilder = (function () {
         if (deployment === 'soft-cert' && clientFile) {
           zip.file('clientCert.p12', clientFile);
         }
-        zip.folder('MANIFEST')?.file('MANIFEST.xml', manifestXml);
+        zip.folder('MANIFEST')?.file('manifest.xml', manifestXml);
       } else {
         zip.folder('certs')?.file('config.pref', prefXml);
         if (caFile) {
@@ -2040,7 +2040,7 @@ const PackageBuilder = (function () {
         if (deployment === 'soft-cert' && clientFile) {
           zip.folder('certs')?.file('clientCert.p12', clientFile);
         }
-        zip.folder('MANIFEST')?.file('MANIFEST.xml', manifestXml);
+        zip.folder('MANIFEST')?.file('manifest.xml', manifestXml);
       }
 
       // Add extra files preserving names


### PR DESCRIPTION
## Problem

ATAK data packages were using incorrect filename casing for the manifest file, which could cause import failures on case-sensitive filesystems.

## Analysis

The ATAK source code explicitly defines the manifest path as:
```java
public static final String MANIFEST_PATH = "MANIFEST";
static final String MANIFEST_XML = MANIFEST_PATH + File.separator + "manifest.xml";
```

This creates the path `MANIFEST/manifest.xml` (lowercase filename).

qrtak was incorrectly generating `MANIFEST/MANIFEST.xml` (uppercase filename), which could fail on Linux and some Android configurations.

## Changes

- Fixed manifest filename in PackageBuilder (main.js:2034, 2043)
- Updated tests to expect lowercase manifest.xml
- Updated documentation in data-packages.md and index.html
- All tests passing (12/12)

## Testing

```bash
npm test -- packageBuilder.test.js
```

All package builder tests pass with the corrected filename.

## Breaking Change

This is technically a breaking change as the generated packages now have a different internal structure. However, this change makes packages **more** compatible with ATAK's expectations.

---

Reported-by: https://github.com/ampledata