### PR TITLE
fix(fonts): self-host Inter to remove runtime Google Fonts dependency

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,7 @@ This project implements several security measures:
 ### Code Security
 - Content Security Policy (CSP) headers
 - No external dependencies in production code (except QR code library)
+- No external network requests at runtime — all assets, including fonts, are vendored and served locally (works fully air-gapped)
 - Input validation and sanitization
 - Secure defaults for all configurations
 

--- a/index.html
+++ b/index.html
@@ -22,10 +22,7 @@
     <link rel="icon" type="image/png" sizes="192x192" href="icon-192.png">
     <link rel="icon" type="image/png" sizes="512x512" href="icon-512.png">
     
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Fonts: self-hosted Inter (bundled via @fontsource in src/js/main.js); no external requests at runtime -->
 
     <!-- Styles & Scripts -->
     <link rel="stylesheet" href="src/styles/main.css">

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ export default {
   coverageReporters: ['text', 'lcov', 'html'],
   setupFilesAfterEnv: ['<rootDir>/src/js/__tests__/setup.js'],
   moduleNameMapper: {
-    '^qrcode$': '<rootDir>/src/js/__tests__/__mocks__/qrcode.js'
+    '^qrcode$': '<rootDir>/src/js/__tests__/__mocks__/qrcode.js',
+    '\\.(css|woff2?|ttf|eot)$': '<rootDir>/src/js/__tests__/__mocks__/styleMock.js'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.0.7",
       "license": "MIT",
       "dependencies": {
+        "@fontsource/inter": "^5.2.8",
         "jszip": "^3.10.1",
         "qrcode": "^1.5.4"
       },
@@ -93,6 +94,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1904,6 +1906,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1927,6 +1930,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2572,6 +2576,15 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4330,6 +4343,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4735,6 +4749,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5527,6 +5542,7 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8244,6 +8260,7 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9002,6 +9019,7 @@
       "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -10225,6 +10243,7 @@
       "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.14.0",
@@ -11114,6 +11133,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "vite-plugin-pwa": "^1.3.0"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.8",
     "jszip": "^3.10.1",
     "qrcode": "^1.5.4"
   },

--- a/src/js/__tests__/__mocks__/styleMock.js
+++ b/src/js/__tests__/__mocks__/styleMock.js
@@ -1,0 +1,3 @@
+// Stub for non-JS asset imports (CSS, fonts) under Jest.
+// Vite resolves these at build time; Jest only needs the import to no-op.
+export default {};

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,4 +1,11 @@
 /* global __APP_VERSION__ */
+// Self-hosted Inter (latin subset, weights used by the design system).
+// Vendored via @fontsource so Vite bundles + content-hashes the woff2 and the
+// PWA precaches them — zero external font requests at runtime (works air-gapped).
+import '@fontsource/inter/latin-400.css';
+import '@fontsource/inter/latin-500.css';
+import '@fontsource/inter/latin-600.css';
+import '@fontsource/inter/latin-700.css';
 import QRCode from 'qrcode';
 import {
   debounce,

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,7 +14,7 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg}']
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff,woff2}']
       },
       manifest: {
         name: 'qrtak',


### PR DESCRIPTION
Closes #313

## Problem

qrtak loads the **Inter** font from the Google Fonts CDN (`fonts.googleapis.com` / `fonts.gstatic.com`). But the production nginx CSP already locks fonts down:

```
style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self';
```

That CSP **blocks both** the external stylesheet and the font files. So:

- **Inter has never rendered in any Docker/nginx deployment** — online or offline. Users silently fell back to the system font (`Segoe UI` / `system-ui`).
- The app **cannot run air-gapped**, since it still reaches out for fonts in environments (e.g. the Vite dev server) where the CSP isn't enforced.

This is a real concern for a TAK onboarding tool intended for disconnected / DDIL deployments.

## Fix

Vendor Inter locally via [`@fontsource/inter`](https://fontsource.org/fonts/inter) instead of the CDN:

- **`index.html`** — remove the Google Fonts `<link>` + `<preconnect>` tags.
- **`src/js/main.js`** — import the latin-subset CSS for the weights the design system uses (400/500/600/700). Vite bundles and **content-hashes** the woff2 (cache-busting handled).
- **`vite.config.js`** — add `woff`/`woff2` to the `vite-plugin-pwa` `globPatterns` so the fonts are **precached for offline** (the default glob omits them).
- **`jest.config.js`** — map CSS/font asset imports to a stub (`__mocks__/styleMock.js`); Vite resolves these at build time, Jest doesn't need them.
- **`SECURITY.md`** — document the air-gapped, no-runtime-external-requests guarantee.

### Why `@fontsource` rather than committing the woff2 directly
- Pinned + integrity-hashed in `package-lock.json` → auditable, reproducible, supply-chain-clean.
- No opaque binaries in git history; clean update path via npm.
- License ships with the package.

### CSP
**No change needed** — `font-src 'self'` already permits the self-hosted fonts. The lockdown that broke Google Fonts is exactly what self-hosting wants.

## Heads-up: this is a visible change
Because Inter never actually loaded in Docker, this PR will make Docker users render **Inter for the first time** instead of the system fallback. That's the intended outcome, but it is a real visual change worth eyeballing.

## Verification
- `npm run build` ✅ — 4 latin woff2 emitted (~24 KB each), content-hashed.
- `grep -ri 'googleapis\|gstatic' dist/` → **zero** references.
- Service worker precache manifest includes all 4 `inter-latin-*.woff2`.
- `npm run lint` ✅ clean.
- `npm test` ✅ 146/146 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)