### PR TITLE
chore(security): add dependency cooldown to Renovate (anti-supply-chain-worm)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,11 @@
   "assignees": ["joshuafuller"],
   "reviewers": ["joshuafuller"],
   "labels": ["dependencies", "renovate"],
-  "schedule": ["before 8am on monday"]
+  "schedule": ["before 8am on monday"],
+  "minimumReleaseAge": "5 days",
+  "internalChecksFilter": "strict",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "1 day",
+    "labels": ["security", "vulnerability"]
+  }
 }


### PR DESCRIPTION
## Why
The active **Shai-Hulud / Mini Shai-Hulud / node-ipc** npm worm waves (May 2026) publish malicious package versions that are **detected and yanked within hours-to-days**. The single most effective defense is a **cooldown**: don't adopt a dependency version until it has survived in the wild.

## What
- `minimumReleaseAge: "5 days"` + `internalChecksFilter: "strict"` — Renovate won't propose/merge an update until the version is 5 days old.
- `vulnerabilityAlerts.minimumReleaseAge: "1 day"` — genuine security fixes still flow fast (but not zero-age).

## Effect
A malicious `node-ipc@9.1.6`-style release would never be pulled in during its live window; by the time the cooldown elapses npm has removed it. Low cost (updates land a few days later); high payoff against the current threat.

Part of the layered supply-chain hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)