### PR TITLE
ci(security): add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,6 +16,7 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read           # job-level perms REPLACE workflow-level — must re-grant read
       security-events: write   # upload SARIF to code scanning
       id-token: write          # publish results to the OpenSSF API
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,45 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 4 * * 1'   # weekly, Monday 04:30 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Least-privilege: only what Scorecard needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      id-token: write          # publish results to the OpenSSF API
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 30
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
+        with:
+          sarif_file: results.sarif
+          category: scorecard


### PR DESCRIPTION
Adds continuous **OpenSSF Scorecard** posture scoring — flags supply-chain weaknesses (unpinned deps, missing branch protection, over-broad token permissions, dangerous workflow patterns, etc.) and publishes to code scanning weekly + on push to main.

Fully SHA-pinned; least-privilege (`read-all` default, `security-events`/`id-token: write` only on the analysis job). Gives an objective, trackable security score as the rest of the hardening lands.

Part of the layered supply-chain hardening pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)