### PR TITLE
ci(security): hard-fail pipeline on compromised/critical dependencies

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -73,7 +73,7 @@ jobs:
       # Dependency Scanning
       # Informational: surface all moderate+ advisories (non-blocking).
       - name: npm audit (report)
-        run: npm audit --production --audit-level=moderate || true
+        run: npm audit --audit-level=moderate || true
 
       # HARD GATE: fail the pipeline on a COMPROMISED dependency.
       # - Known-malicious packages are tagged CWE-506 (Embedded Malicious Code)
@@ -87,7 +87,7 @@ jobs:
           set -uo pipefail
           echo "Scanning dependency tree for malicious / critical advisories…"
           audit="$(npm audit --json 2>/dev/null || true)"
-          if printf '%s' "$audit" | grep -qiE '"CWE-506"|malicious package|"malware"'; then
+          if printf '%s' "$audit" | grep -qiE 'CWE-50[67]|malware|malicious (package|code|version|dependenc)'; then
             echo "::error title=Compromised dependency::A known-malicious package is in the dependency tree — failing the build."
             printf '%s' "$audit" | python3 -c "import sys,json; d=json.load(sys.stdin); [print('::error::', k, '->', v.get('severity'), [ (x.get('title') if isinstance(x,dict) else x) for x in v.get('via',[]) ]) for k,v in d.get('vulnerabilities',{}).items()]" 2>/dev/null || true
             exit 1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -71,8 +71,30 @@ jobs:
             p/owasp-top-ten
 
       # Dependency Scanning
-      - name: npm audit
+      # Informational: surface all moderate+ advisories (non-blocking).
+      - name: npm audit (report)
         run: npm audit --production --audit-level=moderate || true
+
+      # HARD GATE: fail the pipeline on a COMPROMISED dependency.
+      # - Known-malicious packages are tagged CWE-506 (Embedded Malicious Code)
+      #   in the GitHub Advisory DB; we fail on these at ANY severity.
+      # - Critical-severity advisories also block (defense in depth).
+      # Audits the full tree (incl. dev deps — worms often hit build tooling).
+      # Threshold is `critical` so routine moderate/high dev CVEs don't break CI;
+      # malware is caught regardless of severity via the CWE-506 check.
+      - name: Block malicious or critical dependencies
+        run: |
+          set -uo pipefail
+          echo "Scanning dependency tree for malicious / critical advisories…"
+          audit="$(npm audit --json 2>/dev/null || true)"
+          if printf '%s' "$audit" | grep -qiE '"CWE-506"|malicious package|"malware"'; then
+            echo "::error title=Compromised dependency::A known-malicious package is in the dependency tree — failing the build."
+            printf '%s' "$audit" | python3 -c "import sys,json; d=json.load(sys.stdin); [print('::error::', k, '->', v.get('severity'), [ (x.get('title') if isinstance(x,dict) else x) for x in v.get('via',[]) ]) for k,v in d.get('vulnerabilities',{}).items()]" 2>/dev/null || true
+            exit 1
+          fi
+          # Fail on any critical-severity advisory (malware is typically critical too).
+          npm audit --audit-level=critical
+          echo "✓ No malicious or critical advisories."
 
       - name: Snyk Security Scan
         if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
## Why
Every dep scanner in qrtak CI (npm audit, Snyk, OSV, Trivy, Grype) is **non-blocking** today — a known-malicious dependency would appear in the Security tab but the PR stays green and mergeable. There was **no reactive gate** that fails on a compromised dep.

## What
Adds a **blocking gate** in `security.yml` that fails the build when:
- a **known-malicious package** is present — GHSA tags these **CWE-506** (Embedded Malicious Code) / 'malicious package' — at **any severity**, or
- any **critical**-severity advisory exists.

Threshold is `critical` so routine moderate/high *dev* CVEs (e.g. today's `brace-expansion`/`ws` ReDoS) don't break CI, while a node-ipc/Shai-Hulud-style compromise **hard-stops the merge**. Audits the **full tree** (incl. dev deps — worms favor build tooling). Other scanners stay as non-blocking SARIF reporting for breadth.

## Validated
- Passes on the current tree (2 moderate dev CVEs → ignored, no false break).
- Correctly detects CWE-506 / malicious-package advisories (fails) and ignores clean moderate CVEs (negative control).

Completes the reactive half of the L1 dependency-intake layer (the cooldown #315 is the proactive half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)